### PR TITLE
 seoyeon / 4월 1주차 화요일 / 2문제

### DIFF
--- a/seoyeon/백준/BFS&DFS/2573.py
+++ b/seoyeon/백준/BFS&DFS/2573.py
@@ -1,0 +1,173 @@
+#백준 #2573 빙산
+#16:49 - 17:57
+
+# # 1. PyPy3로 해결. BUT Python3의 경우 시간 초과 발생
+# # 시간측정->1.84초 (start_time=time.time(), end_time=time.time(), end_time-start_time)
+# # #시간복잡도 O(N*M)
+# from collections import deque
+# import copy
+
+# #solv() -> O(1)
+# def solv(x,y):
+#     d = [[-1,0],[1,0],[0,-1],[0,1]]
+#     water = 0
+
+#     for dx,dy in d:
+#         nx = x+dx
+#         ny = y+dy
+#         if 0<=nx<N and 0<=ny<M and mountains[nx][ny]==0:
+#             water += 1
+    
+#     if (mountains[x][y]-water)>=0:
+#         return mountains[x][y]-water
+#     else:
+#         return 0
+
+# #bfs() -> O(10,000).X는 빙산 개수.최대 10,000
+# def bfs(x,y,visited):
+#     d = [[-1,0],[1,0],[0,-1],[0,1]]
+    
+#     Q=deque()
+#     Q.append([x,y])
+
+#     while Q:
+#         xx,yy = Q.popleft()
+#         for dx,dy in d:
+#             nx = xx+dx
+#             ny = yy+dy
+#             if 0<=nx<N and 0<=ny<M and mountains[nx][ny]!=0 and visited[nx][ny]==False:
+#                 visited[nx][ny]=True
+#                 Q.append([nx,ny])
+
+#     return visited
+
+# #count() -> O(N*M)
+# def count():
+#     visited = [[False for _ in range(M)] for _ in range(N)]
+#     mountains_n = 0
+#     for i in range(N):
+#         for j in range(M):
+#             if mountains[i][j]!=0 and visited[i][j]==False:
+#                 if mountains_n==0:
+#                     mountains_n += 1
+#                     visited[i][j]=True
+#                     visited = bfs(i,j,visited)
+#                 #빙하가 2 이상인 경우 더 계산할 필요없음
+#                 else:
+#                     return 2
+
+#     return mountains_n
+
+# ## 시간제한:1초 = 20,000,000 (=2*10^7)
+# ## 3<=N,M<=300, 빙산이 차지하는 칸의 개수는 10,000개 이하
+# N,M = map(int,input().split())
+# mountains = [[0 for _ in range(M)] for _ in range(N)]
+# for n in range(N):
+#     mountains[n]=list(map(int,input().split()))
+
+# t = 0
+# while True:
+#     t += 1
+#     #초당 빙산 업데이트
+#     change = copy.deepcopy(mountains)
+
+#     for i in range(N):
+#         for j in range(M):
+#             if mountains[i][j]>0:
+#                 change[i][j] = solv(i,j) #바로 mountains에 적용하면 안 됨
+    
+#     #변경사항 한 번에 적용
+#     mountains = change
+
+#     #종료: (원하던 결과) 빙산 분리 
+#     if count()==2:
+#         break
+#     #종료: 빙산이 다 녹을 때까지 분리되지 않은 경우 0 출력
+#     elif count()==0:
+#         t=0
+#         break
+
+# print(t)
+
+#---------------
+
+#2. Python3로 해결
+#
+from collections import deque
+
+#solv() -> O(1)
+def solv(x,y):
+    d = [[-1,0],[1,0],[0,-1],[0,1]]
+    water = 0
+
+    for dx,dy in d:
+        nx = x+dx
+        ny = y+dy
+        if 0<=nx<N and 0<=ny<M and mountains[nx][ny]==0:
+            water += 1
+    
+    if (mountains[x][y]-water)>=0:
+        return mountains[x][y]-water
+    else:
+        return 0
+
+#bfs() -> O(10,000).X는 빙산 개수.최대 10,000
+def bfs(x,y):
+    d = [[-1,0],[1,0],[0,-1],[0,1]]
+    
+    visited[x][y]=True
+    Q=deque()
+    Q.append([x,y])
+
+    while Q:
+        xx,yy = Q.popleft()
+        for dx,dy in d:
+            nx = xx+dx
+            ny = yy+dy
+            if 0<=nx<N and 0<=ny<M and mountains[nx][ny]!=0 and visited[nx][ny]==False:
+                visited[nx][ny]=True
+                Q.append([nx,ny])
+
+    return visited
+
+## 시간제한:1초 = 20,000,000 (=2*10^7)
+## 3<=N,M<=300, 빙산이 차지하는 칸의 개수는 10,000개 이하
+N,M = map(int,input().split())
+mountains = [[0 for _ in range(M)] for _ in range(N)]
+for n in range(N):
+    mountains[n]=list(map(int,input().split()))
+
+ice_lst = []
+for i in range(N):
+    for j in range(M):
+        if mountains[i][j]!=0:
+            ice_lst.append([i,j])
+
+t = 0
+while True:
+    t += 1
+    #초당 빙산 업데이트
+    change = [item[:] for item in mountains] #[Point1.deepcopy는 시간복잡도가 커 슬라이스로 변환]
+
+    for i in range(N):
+        for j in range(M):
+            if mountains[i][j]>0:
+                change[i][j] = solv(i,j) #바로 mountains에 적용하면 안 됨
+    
+    #변경사항 한 번에 적용
+    mountains = change
+
+    #BFS
+    visited = [[False for _ in range(M)] for _ in range(N)]
+    cnt = 0 #빙하 덩어리 개수
+    for x,y in ice_lst: #[Point2.이중for문이 아닌 ice_lst로 변경]
+        if mountains[x][y]!=0 and visited[x][y]==False:
+            cnt += 1
+            bfs(x,y)
+
+    if cnt>=2:
+        break
+    elif cnt==0:
+        t=0
+        break
+print(t)

--- a/seoyeon/프로그래머스/알고리즘 고득점 Kit/스택/큐/프로세스.py
+++ b/seoyeon/프로그래머스/알고리즘 고득점 Kit/스택/큐/프로세스.py
@@ -1,0 +1,39 @@
+from collections import deque
+from collections import defaultdict
+
+def solution(priorities, location):
+    answer = 0
+    
+    #location과 비교하기 위해 index와 함께 Q에 삽입
+    lst = [[] for _ in range(len(priorities))]
+    for i in range(len(priorities)):
+        lst[i] = [priorities[i],i]
+
+    Q = deque(lst)
+    
+    #Q에 존재하는 수와 개수 카운트
+    dict = defaultdict(int)
+    
+    for i in priorities:
+        if i not in dict:
+            dict[i] = 1
+        else:
+            dict[i] += 1
+        
+    while Q:
+        x,idx = Q.popleft()
+        #1.x가 Q에서 가장 큰 수인 경우 
+        if x==max(dict.keys()):
+            #실행되었으므로 순서 1 증가
+            answer += 1 
+            dict[x] -= 1
+            #dict[x]==0인 경우 dict에서 제거
+            if dict[x]==0:
+                del dict[x]
+            #idx==location인 경우 찾고자 했던 값이므로 반복문 종료
+            if idx==location:
+                break
+        #2.그렇지 않은 경우 다시 넣기
+        else:
+            Q.append([x,idx])
+    return answer


### PR DESCRIPTION
## [PSG] 프로세스
#### ⏰ 00:20  📌 큐 📈 O
### 문제
<https://school.programmers.co.kr/learn/courses/30/lessons/42587>

### 문제 해결

> 시간복잡도 O(N).N:priorities 개수
> 

1. 문제에서 구하고자 하는 location임을 확인해야 하므로 Q에 넣을 때 값과 인덱스 함께 넣어야 함 
- lst 사용
2. Q에 존재하는 수와 해당 수가 몇 개인지 카운트해야하므로 defaultdict 사용
3. Q를 하나씩 탐색
  a. Q에서 뺀 수 x가 defaultdict에 존재하는 가장 큰 수인 경우 프로세스 실행    
    - 실행한 프로세스 개수 answer 증가
    - dict에서 개수 1 제거
    - 만약 dict에 해당 수가 남아 있지 않는 경우 제거 
    - 만약 해당 수에 해당하는 인덱스가 location인 경우 종료
  
    b. 그렇지 않은 경우 다시 Q에 넣음

### 피드백

defaultdict 사용 문제

## [BOJ] 빙산
#### ⏰ 02:00  📌 BFS 📈 X
### 문제
<https://www.acmicpc.net/problem/2573>

### 문제 해결

> 시간복잡도 O(N*M)
> 

1. ice_lst에 빙산인 x,y 좌표 넣기 
- 추후 bfs 탐색 시 사용
2. 매 초마다 반복
  a. 인근 바다의 개수만큼 mountains가 줄어드는데, 즉시 변경하면 안 되고 모두 탐색한 후 한 번에 변경
  
    - 이때 deepcopy 사용하면 시간 초과 발생
  
    b. BFS로 빙하 덩어리 수 계산
  
    - 이때 `for i in range(N), for j in range(M)`으로 모든 좌표 탐색하면 시간 초과 발생
    - 처음에 저장한 ice_lst 데이터만 탐색
  
    c. cnt에 따라 계산
    - cnt>=2인 경우 원하는 결과이므로 break 후 t 출력
    - cnt==0인 경우 빙하가 모두 녹은 상황이므로 0 출력
    - (그외. cnt==1) 반복문 계속 동작

### 피드백

스스로 풀었을 때 Python3로는 시간초과, PyPy로는 해결 -> [풀이1]

BUT Python3로 해결할 수 있었던 방법 -> [풀이2]

1. deepcopy는 시간복잡도가 크기 때문에 슬라이싱으로 복사할 것 
2. 이중 for문으로 bfs를 탐색하지 말고 처음에 빙하의 좌표를 저장하고 해당 리스트에서 하나씩 빼 사용