### PR TITLE
 seoyeon / 4월 1주차 수요일 / 2문제

### DIFF
--- a/seoyeon/백준/투포인터/1644.py
+++ b/seoyeon/백준/투포인터/1644.py
@@ -1,0 +1,45 @@
+#백준 #1644 소수의연속합
+
+N = int(input())
+
+dp = [False for _ in range(N+1)] #소수인 경우 True
+
+#소수
+lst = []
+
+#소수 계산
+for i in range(2,N+1): #Check1.N까지가 아니라 N+1까지해야 자기자신이 소수인 경우도 처리 가능
+    if dp[i]==False:
+        dp[i]=True
+        lst.append(i)
+    else:
+        continue
+    
+    current = i
+    while current<N+1: #Check2.N까지가 아니라 N+1까지 해야 마지막 수의 소수 판별 가능
+        dp[current]=True
+        current+=i
+
+#lst는 정렬되어 있으므로 투포인터 사용
+start,end = 0,0
+sum = 0
+answer = 0
+while end<len(lst)+1:
+    sum = 0
+    for i in range(start,end):
+        sum += lst[i]
+
+    #N인 경우 다음 경우의 수 탐색
+    if sum==N:
+        answer += 1
+        start += 1
+        continue
+
+    #N보다 작은 경우 end 증가
+    if sum < N:
+        end += 1
+    #N보다 큰 경우 start 증가
+    elif sum > N:
+        start += 1
+
+print(answer)

--- a/seoyeon/프로그래머스/SQL 고득점 Kit/대여 횟수가 많은 자동차들의 월별 대여 횟수 구하기.sql
+++ b/seoyeon/프로그래머스/SQL 고득점 Kit/대여 횟수가 많은 자동차들의 월별 대여 횟수 구하기.sql
@@ -1,0 +1,35 @@
+-- 내 코드: "특정 월의 총 대여 횟수가 0인 경우 제외" 조건 해결 못함
+SELECT month(START_DATE), CAR_ID, COUNT(*) as RECORDS
+FROM CAR_RENTAL_COMPANY_RENTAL_HISTORY
+WHERE "2022-08" <= date_format(START_DATE,"%Y-%m") <= "2022-10"
+GROUP BY month(START_DATE), CAR_ID
+HAVING RECORDS>=5
+ORDER BY month(START_DATE), CAR_ID DESC
+
+-- 2 틀렸습니다
+SELECT month(START_DATE), CAR_ID, COUNT(*) as RECORDS
+FROM CAR_RENTAL_COMPANY_RENTAL_HISTORY
+WHERE "2022-08" <= date_format(START_DATE,"%Y-%m") <= "2022-10"
+    and CAR_ID in (SELECT CAR_ID FROM CAR_RENTAL_COMPANY_RENTAL_HISTORY WHERE "2022-08" <= date_format(START_DATE,"%Y-%m") <= "2022-10" GROUP BY CAR_ID HAVING COUNT(CAR_ID)>=5) 
+GROUP BY month(START_DATE), CAR_ID
+HAVING RECORDS>=1
+ORDER BY month(START_DATE), CAR_ID DESC
+
+--3 정답. date_format은 between을 사용해 해결
+SELECT month(START_DATE), CAR_ID, COUNT(HISTORY_ID) as RECORDS
+FROM CAR_RENTAL_COMPANY_RENTAL_HISTORY
+WHERE date_format(START_DATE,"%Y-%m") BETWEEN "2022-08" and "2022-10"
+    and CAR_ID in (SELECT CAR_ID FROM CAR_RENTAL_COMPANY_RENTAL_HISTORY WHERE date_format(START_DATE,"%Y-%m") BETWEEN "2022-08" and "2022-10" GROUP BY CAR_ID HAVING COUNT(CAR_ID)>=5) 
+GROUP BY month(START_DATE), CAR_ID
+HAVING RECORDS>=1
+ORDER BY month(START_DATE), CAR_ID DESC
+
+--4.의문. 왜 where에 date 관련 조건이 하나 더 있어야 하지?
+select month(start_date), car_id, count(car_id) as records
+from car_rental_company_rental_history
+
+where car_id in (select car_id from car_rental_company_rental_history where date_format(start_date,"%Y-%m") between "2022-08" and "2022-10" group by car_id having count(car_id)>=5)
+
+group by month(start_date), car_id
+having records >= 1
+order by month(start_date), car_id desc


### PR DESCRIPTION
## [BOJ] 소수의 연속합
#### ⏰ 00:30  📌 투포인터 📈 O
### 문제
<https://www.acmicpc.net/problem/1644>

### 문제 해결

> 시간복잡도 O(N).N:소수 개수
> 

| 연속된 소수의 합으로 나타낼 수 있는 경우의 수 -> 투포인터

1. 소수판별
- 2부터 N(자기자신)까지(range(2,N+1))의 모든 소수 계산해 소수인 경우 lst에 삽입
- 소수인 경우 본인의 배수 dp를 True로 변경해 해당 수가 소수가 아님을 체크
- 이때 current<N+1까지 진행해야 N까지 체크할 수 있음
- lst가 자연스럽게 정렬되어 투포인터 사용 가능
2. 투포인터로 문제 해결
- start,end를 0,0으로 정의
- end가 len(lst)+1이 된 경우 인덱스를 넘어가므로 종료
- start부터 end까지의 합 sun을 구함
- 만약 sum==N인 경우 경우의 수 `answer += 1`
- sum<N인 경우 더 해야하므로 `end += 1`
- sum>N인 경우 줄여야 하므로 `start += 1`

### 피드백

소수 계산 시 마지막 수(N)도 소수인지 확인해야 하며, 소수의 배수를 체크할 때에도 N까지 체크해야 함 

## [PSG] 대여 횟수가 많은 자동차들의 월별 대여 횟수 구하기
#### ⏰ 01:20  📌 SQL 📈 X
### 문제
<https://school.programmers.co.kr/learn/courses/30/lessons/151139>

### 문제 해결

1. select
- 월별, 자동차 아이디별 데이터 개수를 records로 설정
2. where
- 이때 date_format()과 car_id 서브쿼리 존재
- car_id를 위한 서브쿼리를 통해 car_id 결정
- date_format()을 서브쿼리에서 진행했으므로 하지 않으면, 해당 car_id의 모든 날짜별 데이터가 카운트되어 오류 발생
3. group by 
- 월별, car_id별 그룹화 진행
4. order by
- 월별 오름차순, car_id 별 내림차순 정렬

### 피드백

1. date_format()으로 날짜 포맷 변경 후 부등호로 해당 날짜에 존재한다고 작성하면 안됨. `between 시작 and 종료`로 해결해야함
2. where절과 서브 쿼리문 이해 부족
