### PR TITLE
seoyeon / 7월 3주차 수요일 / 1문제

### DIFF
--- a/seoyeon/BaekJoon/codemonster/1753.py
+++ b/seoyeon/BaekJoon/codemonster/1753.py
@@ -1,4 +1,4 @@
-#MST - Kruskal's Algorithm
+#Dijkstra
 
 import heapq,sys
 

--- a/seoyeon/BaekJoon/codemonster/1753.py
+++ b/seoyeon/BaekJoon/codemonster/1753.py
@@ -1,0 +1,45 @@
+#MST - Kruskal's Algorithm
+
+import heapq,sys
+
+input = sys.stdin.readline
+
+V, E = map(int,input().split())
+
+v = [i for i in range(V)]
+edges = [[] for _ in range(V)] #edges[x]=[[y,w],...] #x->y까지 w만큼 소요
+distance = [float("inf") for _ in range(V)]
+
+K = int(input())
+distance[K-1]=0
+
+for _ in range(E):
+    u,v,w = map(int,input().split()) #u->v
+    edges[u-1].append([w,v-1])
+
+def dijkstra(start):
+
+    heap = []
+    heapq.heapify(heap)
+    heapq.heappush(heap, [0,start])
+
+    #최단거리가 짧은 순서대로 진행
+    while heap:
+        current_cost, current_index = heapq.heappop(heap)
+
+        if current_cost > distance[current_index]:
+            continue
+
+        for next_cost,next_index in edges[current_index]:
+            cost = current_cost+next_cost #next는 [y,w]
+            if cost<distance[next_index]:
+                distance[next_index] = cost
+                heapq.heappush(heap,[cost,next_index])
+
+dijkstra(K-1)
+
+for i in range(V):
+    if distance[i]==float("inf"):
+        print("INF")
+    else:
+        print(distance[i])


### PR DESCRIPTION
## [BOJ] 1753 최단경로
#### ⏰ 01:20  📌 Dijkstra 📈 X
### 문제
<https://www.acmicpc.net/problem/1753>

### 문제 해결

> 시간복잡도 O(ElogV)
> 

아이디어: 가중치가 작은 간선을 순서대로 뽑아 계산
1. 입력으로 들어온 간선 넣기 
- edges[x] = [[w1,y1],[w2,y2],...] 는 x에서 y1, y2로 가는 각각의 가중치가 w1, w2
2. dijkstra(start)
- heapq에 시작 인덱스와 가중치 넣기 `heapq.heappush(heap, [0,start])`
  - 가중치를 먼저 넣어야 작은 순서대로 간선 고를 수 있음
- heapq.heappop(heap)으로 뺀 인덱스의 distance 값이 존재하면 continue
- 그렇지 않은 경우 다음으로 갈 수 있는 인덱스 for문으로 뽑음
  - 다음 인덱스까지의 가중치 cost 계산 후 다음 인덱스의 distance 값보다 작은 경우 distance 업데이트 & heapq에 삽입
3. 출력
- distance가 float("inf")인 경우 "INF" 출력, 그렇지 않은 경우 distance 값 출력

### 피드백

Dijkstra는 하나의 출발점에서 다른 모든 노드까지의 거리를 구함
이때 시작점에서 시작해 가중치가 가장 작은 간선을 Greedy하게 계산
`if cost<distance[next_index]`로 새로운 경로가 기존 경로보다 가중치가 작은 경우 distance 업데이트하여 항상 최솟값 보장