### PR TITLE
seoyeon / 9월 4주차 목요일 / 2문제

### DIFF
--- a/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15684.py
+++ b/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15684.py
@@ -77,7 +77,8 @@ def backtracking(x,y,cnt):
                 ladders[i][j]=True
                 backtracking(i,j+2,cnt+1)
                 ladders[i][j]=False
-            # #2.ladders True
+            #**아래 코드는 backtracking()을 호출해 탐색 공간만 늘리고 답에는 영향 주지 않음
+            #  #2.ladders True
             # elif ladders[i][j]:
             #     backtracking(i,j+2,cnt)
 

--- a/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15684.py
+++ b/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15684.py
@@ -1,5 +1,5 @@
 #백준 #15684 사다리조작
-#8:22-
+#8:22-10:24
 
 N,M,H = map(int,input().split())
 ladders = [[False for _ in range(N)] for _ in range(H)]

--- a/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15684.py
+++ b/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15684.py
@@ -1,0 +1,89 @@
+#백준 #15684 사다리조작
+#8:22-
+
+N,M,H = map(int,input().split())
+ladders = [[False for _ in range(N)] for _ in range(H)]
+
+for m in range(M):
+    a, b = map(int,input().split()) #a:H, b:b와 b+1 연결
+    ladders[a-1][b-1]=True
+
+answer = float("inf")
+
+#O(N*H)
+def check():
+
+    #**current에 맞춰 h 진행! n에 맞추는 것 아님
+    for n in range(N):
+        current = n
+        for h in range(H):
+            if current>0 and ladders[h][current-1]:
+                current -= 1
+            elif ladders[h][current]:
+                current += 1
+        if current!=n:
+            return False
+        
+    return True
+    #** 리스트 만들 필요 없음 -> 시간초과
+    # parents = [i for i in range(N)]
+
+    # for i in range(H):
+    #     for j in range(N-1):
+    #         if ladders[i][j]==True:
+    #             parents[j], parents[j+1] = parents[j+1], parents[j]
+
+    # for k in range(N):
+    #     if parents[k]!=k:
+    #         return False
+    # return True
+
+#전체 시간복잡도 O((N*H)^2)
+#ladders를 모두 돌면서 backtracking
+#ladders[x][y]가 False일 때 True로 변경 후 다시 추적
+def backtracking(x,y,cnt):
+    global answer
+
+    if check():
+        answer = min(answer,cnt)
+        return
+    
+    if cnt>=3 or cnt>=answer:
+        return
+
+    #y>N-1인 경우 현재 x에서 탐색할 ladder 없음
+    #**이렇게 하면 안 됨!
+    # if y>N-1:
+    #     x+=1
+    #     y=0
+
+    #i는 x부터 H-1, j는 y부터 N-2
+    #j는 j와 j+1을 연결하는지 확인하기 때문
+    for i in range(x,H):
+        #** j는 i==x일 때 y부터, 그 이후로는 0부터 
+        if i==x:
+            now=y
+        else:
+            now=0
+        for j in range(now,N-1):
+            #두 가로선이 연속하면 안 되므로!
+            #ladders[i][j]. 즉, j와 j+1 연결 -> j+2와 j+3 연결 확인 필요
+            #**ladders[i][j+1]도 False여야 함. ladders[i][j-1]은 elif에서 탐색
+                    
+            #1.ladder False
+            if ladders[i][j]==False and ladders[i][j+1]==False:
+                if j>0 and ladders[i][j-1]==True:
+                    continue
+                ladders[i][j]=True
+                backtracking(i,j+2,cnt+1)
+                ladders[i][j]=False
+            # #2.ladders True
+            # elif ladders[i][j]:
+            #     backtracking(i,j+2,cnt)
+
+backtracking(0,0,0)
+
+if answer==float("inf"):
+    print(-1)
+else:
+    print(answer)

--- a/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15685.py
+++ b/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15685.py
@@ -44,7 +44,6 @@ def curve(k,d,g,x,y,prev):
 
         ex,ey = prev[-1]
         current=[]
-        #print("Q",Q)
 
         while Q:
             cx,cy = Q.pop()
@@ -68,8 +67,8 @@ def curve(k,d,g,x,y,prev):
             nx, ny = ex+tmp_x, ey+tmp_y
             current.append([nx,ny])
             boards[nx][ny]=1
-
-        
+        # print("prev",prev)
+        # print("current",current)
         curve(k+1,d,g,x,y,prev+current)
 
 def check():
@@ -77,8 +76,9 @@ def check():
 
     check_d = [[0,1],[1,0],[1,1]]
 
-    for i in range(99):
-        for j in range(99):
+    #0<=x,y<=100 이므로 99가 아니라 100까지
+    for i in range(100):
+        for j in range(100):
             if boards[i][j]==1:
                 cnt = 1
                 for dd in range(3):

--- a/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15685.py
+++ b/seoyeon/BaekJoon/Folder/Samsung_SW_Test/15685.py
@@ -1,0 +1,110 @@
+#백준 #15685 드래곤 커브
+
+#100*100 격자에 드래곤 커브 N개 존재
+#출력:크기가 1*1인 정사각형의 네 꼭짓점이 모두 드래곤 커브의 일부인 정사각형의 개수
+from collections import deque
+
+N = int(input())
+dragon_curves = [[] for _ in range(N)] #dragon_curves=[[시작x,시작y,시작방향,세대]]
+for n in range(N):
+    dragon_curves[n] = list(map(int,input().split()))
+
+boards = [[0 for _ in range(101)] for _ in range(101)]
+answer = 0
+
+#1.curve에 따라 boards 채우기
+# g=10까지 진행 <- 문제에 주어짐
+#2.boards 탐색해 1*1 정사각형의 네 꼭짓점 확인
+# boards가 1인 경우 dragon_curve에 해당
+
+dir = [[0,1],[-1,0],[0,-1],[1,0]]
+
+def curve(k,d,g,x,y,prev):
+    global boards
+
+    #종결조건: g세대 드래곤 커브까지만 진행
+    if k==g+1:
+        return 
+    
+    #0세대 드래곤 커브 정의
+    elif k==0:
+        curve_lst = [[x,y], [x+dir[d][0],y+dir[d][1]]]
+        boards[x][y]=1
+        boards[x+dir[d][0]][y+dir[d][1]]=1
+
+        curve(k+1,d,g,x,y,curve_lst)
+    
+    #1세대 이후 드래곤 커브 
+    #1. 끝점 탐색
+    #2. prev에서 값 popleft() 후 90도 회전
+    # 끝점과 회전한 값으로 새로운 좌표 탐색
+    #3. 새로운 좌표 boards 업데이트, 다음에 넘길 prev 리스트애 넣기
+    else:
+        Q = deque(prev)
+
+        ex,ey = prev[-1]
+        current=[]
+        #print("Q",Q)
+
+        while Q:
+            cx,cy = Q.pop()
+            #print("cxcy",cx,cy)
+            if [cx,cy]==prev[-1]:
+                continue
+            #90도 회전
+            #cx 끝점 x로부터 떨어진 만큼(ex-cx) y로 떨어지고
+            #cy 끝점 y로부터 떨어진 만큼(ey-cy) x로 떨어짐
+            tmp_x,tmp_y = 0,0
+            if ey>=cy:
+                tmp_x = -abs(ey-cy)
+            else:
+                tmp_x = abs(ey-cy)
+            
+            if cx>=ex:
+                tmp_y = -abs(ex-cx)
+            else:
+                tmp_y = abs(ex-cx)
+
+            nx, ny = ex+tmp_x, ey+tmp_y
+            current.append([nx,ny])
+            boards[nx][ny]=1
+
+        
+        curve(k+1,d,g,x,y,prev+current)
+
+def check():
+    global answer
+
+    check_d = [[0,1],[1,0],[1,1]]
+
+    for i in range(99):
+        for j in range(99):
+            if boards[i][j]==1:
+                cnt = 1
+                for dd in range(3):
+                    if boards[i+check_d[dd][0]][j+check_d[dd][1]]==1:
+                        cnt += 1
+                    else:
+                        break
+                if cnt==4:
+                    answer += 1
+
+
+#시간복잡도 O(N*g)
+#문제에 주어진대로 boards 업데이트
+for x,y,d,g in dragon_curves:
+    #print("Dragon")
+    curve(0,d,g,y,x,[0,0])
+
+check()
+print(answer)
+
+#N*M
+# [1,2,3]             [10 7 4 1]        [12 11 10]     
+# [4,5,6]             [11 8 5 2]        [9 8 7]        [3 6 9 12]
+# [7,8,9]             [12 9 6 3]        [6 5 4]        [2 5 8 11]
+# [10,11,12]                            [3 2 1]        [1 4 7 10]
+
+# x<N, y<M일 때 
+# [x,y] 
+# 1)[y,-x] 2)[-y,x] 3)[y,M-x-1] 4)[N-y-1,x]


### PR DESCRIPTION
## [BOJ] 15684 사다리조작
#### ⏰ 02:00  📌 Backtracking 📈 X
### 문제
<https://www.acmicpc.net/problem/15684>

### 문제 해결

> 시간복잡도 O((N*H)^2)
> 

1. backtracking(x,y,cnt)
- 종결조건: check()로 정답이거나 cnt>=3 또는 cnt>=answer인 경우 더 탐색할 필요 없음
- [x,y]부터 아래까지의 ladder를 모두 탐색해야 함
  -이중 for문에서 i==x인 경우는 y부터 시작, 그외의 경우는 0부터 시작해야 모든 사다리 탐색 가능
- 현재와 오른쪽 세로선에 사다리가 없고, 만약 왼쪽 범위가 존재한다면 왼쪽에도 사다리가 없어야 함
  - j 범위가 now부터 N-1 미만이므로 j+1<N은 없어도 됨  
- 위를 모두 만족하면 ladders True로 업데이트 후 backtracking, 이후 ladders False로 변경 
2. check()
- 위와 아래의 값이 같은지 확인


### 피드백

Python3로는 시간초과 발생. PyPy3로 해결
check
- N과 H 헷갈림
- parents로 리스트 만들어 처리하려 했는데 변수로 처리하면 됨
backtracking()
- i==x일 때 y부터 시작, 그외의 경우 0부터 시작하는 것을 알지 못 함
- `ladders]i][j]==True`인 경우 재귀했는데, 굳이 재귀할 필요없음
  - 결과에 영향 주지 않고 탐색 범위만 늘어남
- 코드의 아래 내용 없어도 됨! j에서 backtracking 시 j+1이 False임을 탐색하고 j+2로 넘어가므로 이후 backtracking에서 j-1은 반드시 False

```
                if j>0 and ladders[i][j-1]==True:
                    continue
```

## [BOJ] 15685 드래곤커브
#### ⏰ 2시간 이상  📌 구현 📈 O
### 문제
<https://www.acmicpc.net/problem/15685>

### 문제 해결

> 시간복잡도 O(N*g)
> 

1. 입력으로 주어진 dragon_curves를 curve() 파라미터로 삽입
3. curve()
- 종결조건: k==g+1인 경우, g세대 드래곤 커브를 완성했으므로 종료
- 초기: k==0인 경우, 시작 위치와 방향으로 초기 드래곤 커브 리스트 정의
- 이후
  - 파라미터로 받은 리스트에서 값을 하나씩 빼 계산
  - k세대 드래곤 커브는 리스트의 반대로 진행
    - g-1세대의 끝 점에서 g세대 드래곤 커브가 시작해야 하기 때문  
  - g세대 시작 점은 g-1세대 끝점과 동일하므로 continue
  - 현재 값 cx,cy를 90도 회전 -> if-else 절
  - 시작 위치에 90도 회전한 값을 더해 nx,ny 탐색
  - 다음 curve 시 g=0부터 g=k까지의 점이 모두 필요하므로 nx,ny를 current에 삽입 후 파라미터로 이전 리스트와 합침
  - boards 업데이트
  - curve 재귀 -> k세대 종료되었으므로 k+1세대로 넘어가고, 리스트를 prev+current로 설정해 최종 리스트 넘김
4. check()
- 100*100 boards 탐색하면서 1*1 직사각형의 꼭짓점이 모두 드래곤 커브에 해당하는지 확인
- 해당하는 값을 global 변수 answer로 업데이트

### 피드백

nx,ny 계산 시 90도 회전 후 x,y에서 시작하는 작업 복잡